### PR TITLE
chore(lint): remove `babel-eslint`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,5 @@
-parser: babel-eslint
-
 parserOptions:
-  ecmaVersion": 6,
+  ecmaVersion: 2017
   sourceType: module
 
 env:

--- a/package.json
+++ b/package.json
@@ -29,9 +29,8 @@
   },
   "devDependencies": {
     "ava": "^0.16.0",
-    "babel-eslint": "^6.0.4",
     "coveralls": "^2.11.9",
-    "eslint": "^3.0.0",
+    "eslint": "^3.6.0",
     "eslint-config-pedant": "^0.8.0",
     "nyc": "^8.1.0",
     "proxyquire": "^1.7.9",


### PR DESCRIPTION
ESLint v3.6.0 support ES2017 syantax natively.
